### PR TITLE
Upgrade Gatsby deps, 1.2.0. Drop remark-iframe

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -34,12 +34,6 @@ module.exports = {
               maxWidth: 590,
             },
           },
-          {
-            resolve: 'gatsby-remark-responsive-iframe',
-            options: {
-              wrapperStyle: 'margin-bottom: 1.0725rem',
-            },
-          },
           'gatsby-remark-prismjs',
           'gatsby-remark-copy-linked-files',
           'gatsby-remark-smartypants',


### PR DESCRIPTION
gatsby-remark-responsive-iframe currently has issues
interoperating with gatsby-remark-images.